### PR TITLE
Adapt manifests for the development environment

### DIFF
--- a/manifest-templates/dev-env.yaml
+++ b/manifest-templates/dev-env.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dev-env
+  labels:
+    name: dev-env
+  annotations:
+    pod.beta.kubernetes.io/init-containers: '[
+      {
+        "name": "mariadb-dev-user-secrets",
+        "image": "sles12/mariadb:10.0",
+        "command": ["/setup-mysql.sh"],
+        "env": [
+          {
+            "name": "ENV",
+            "value": "development"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/infra-secrets",
+            "name": "infra-secrets",
+            "readOnly": true
+          },
+          {
+            "mountPath": "/var/run/mysql",
+            "name": "mariadb-unix-socket"
+          },
+          {
+            "mountPath": "/setup-mysql.sh",
+            "name": "setup-mysql",
+            "readOnly": true
+          }
+        ]
+      },
+      {
+        "name": "mariadb-test-user-secrets",
+        "image": "sles12/mariadb:10.0",
+        "command": ["/setup-mysql.sh"],
+        "env": [
+          {
+            "name": "ENV",
+            "value": "test"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/infra-secrets",
+            "name": "infra-secrets",
+            "readOnly": true
+          },
+          {
+            "mountPath": "/var/run/mysql",
+            "name": "mariadb-unix-socket"
+          },
+          {
+            "mountPath": "/setup-mysql.sh",
+            "name": "setup-mysql",
+            "readOnly": true
+          }
+        ]
+      }
+    ]'
+spec:
+  containers:
+    - name: dummy-dev-env-container
+      image: sles12/velum:0.0
+      command: ["ls"]
+  volumes:
+    - name: mariadb-unix-socket
+      hostPath:
+        path: /var/run/mysql
+    - name: infra-secrets
+      hostPath:
+        path: /var/lib/misc/infra-secrets
+    - name: setup-mysql
+      hostPath:
+        path: /usr/share/caasp-container-manifests/setup/mysql/setup-mysql.sh

--- a/patch_schema
+++ b/patch_schema
@@ -49,4 +49,5 @@
 CONTAINER_BUILD=`docker run -d sles12/velum:development cp /srv/velum/db/schema.rb /var/lib/velum`
 docker logs -f $CONTAINER_BUILD
 docker commit $CONTAINER_BUILD sles12/velum:development
+docker tag sles12/velum:development sles12/velum:0.0
 docker rm $CONTAINER_BUILD

--- a/process_manifest.rb
+++ b/process_manifest.rb
@@ -50,6 +50,7 @@ def patch_container_envvars(container)
 end
 
 def patch_container_volumes(container)
+  container["volumeMounts"] ||= Array.new
   container["volumeMounts"].reject! do |volume_mount|
     ["salt", "salt-master-config"].include? volume_mount["name"]
   end

--- a/start
+++ b/start
@@ -61,9 +61,9 @@ done
 default_interface=$(awk '$2 == 00000000 { print $1 }' /proc/net/route)
 ip_address=$(ip addr show $default_interface | awk '$1 == "inet" {print $2}' | cut -f1 -d/)
 
-for template in $(ls manifest-templates)
+for template in $(ls manifest-templates/*.yaml)
 do
-    sed -e "s#\${ip_address}#$ip_address#" manifest-templates/$template > manifests/$template
+    cat $template | ruby process_manifest.rb $CONTAINER_MANIFESTS_DIR $VELUM_DIR $SALT_DIR | sed -e "s#\${ip_address}#$ip_address#" > manifests/$(basename $template)
 done
 
 if ! $(which kubelet >&/dev/null); then
@@ -76,16 +76,18 @@ fi
 sudo mkdir -p $PWD/tmp/mariadb-socket
 sudo chmod 777 $PWD/tmp/mariadb-socket
 
-set +e
-docker pull docker-testing-registry.suse.de/sles12/velum:development | grep "up to date" &> /dev/null
-image_up_to_date=$?
-set -e
+if [ -z "$SKIP_IMAGE_UPDATE" ]; then
+  set +e
+  docker pull docker-testing-registry.suse.de/sles12/velum:development | grep "up to date" &> /dev/null
+  image_up_to_date=$?
+  set -e
+fi
 
 if [[ $image_up_to_date -ne 0 ]] ; then
   log "New Velum image found on the registry"
 fi
 
-if [[ $image_up_to_date -eq 0 ]] && ( docker images | grep "^sles12/velum" &> /dev/null ) ; then
+if [[ $image_up_to_date -eq 0 ]] && ( docker images | grep "^sles12/velum" | grep development &> /dev/null ) ; then
   log "Velum development image is present and up to date"
 else
   log "Building Velum development image..."


### PR DESCRIPTION
Also tag the development image as the production image

This will be used occasionally when we need to refer to sles12/velum:0.0
as happens in production.

Add dev-env manifest that will take care of creating databases for
development and test environments, now that we aren't connecting with
the `root` mysql user and our permissions are restricted.