### PR TITLE
Add several salt helper scripts

### DIFF
--- a/lib/functions
+++ b/lib/functions
@@ -1,0 +1,18 @@
+# CaaSP Development Environment Helper Functions
+
+set -euo pipefail
+
+find_container() {
+  local name=$1
+
+  docker ps | grep "${name}" | awk '{print $1}'
+}
+
+exec_in_container() {
+  local name=$1
+  local cmd="${@:2}"
+
+  local container_id=$(find_container $name)
+
+  docker exec -t $container_id $cmd
+}

--- a/scripts/salt-event-log
+++ b/scripts/salt-event-log
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+REPO_ROOT_DIR=$(dirname $(dirname "$(readlink -f "$0")"))
+source $REPO_ROOT_DIR/lib/functions
+
+exec_in_container salt-master "salt-run state.event pretty=True"

--- a/scripts/salt-highstate
+++ b/scripts/salt-highstate
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+REPO_ROOT_DIR=$(dirname $(dirname "$(readlink -f "$0")"))
+source $REPO_ROOT_DIR/lib/functions
+
+exec_in_container salt-master "salt '*' state.highstate"

--- a/scripts/salt-orchestrate
+++ b/scripts/salt-orchestrate
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+REPO_ROOT_DIR=$(dirname $(dirname "$(readlink -f "$0")"))
+source $REPO_ROOT_DIR/lib/functions
+
+ORCHESTRATION=${1?You must supply an orchestration name}
+
+exec_in_container salt-master "salt-run state.orchestrate $ORCHESTRATION"


### PR DESCRIPTION
I'm constantly typoing these, or using `salt '*'` in place of `salt-run`, so I've just added some scripts for the common calls I make against my dev environment.