### PR TITLE
Check for ENV variable as well as RAILS_ENV

### DIFF
--- a/process_manifest.rb
+++ b/process_manifest.rb
@@ -59,7 +59,7 @@ end
 def patch_container_envvars(container)
   (container["env"] || []).each do |envvar|
     case envvar["name"]
-    when "RAILS_ENV"
+    when "RAILS_ENV", "ENV"
       envvar["value"] = "development"
     when "VELUM_PORT"
       envvar["value"] = "3000"


### PR DESCRIPTION
Looks like a mismatch - the Rails code uses RAILS_ENV, but the other
scripts use ENV. Process the ENV variable just like the RAILS_ENV
variable.