### PR TITLE
Patch all volumes for containers starting with `velum-`

### DIFF
--- a/process_manifest.rb
+++ b/process_manifest.rb
@@ -86,7 +86,7 @@ def patch_container_volumes(container)
       [
         container_volume(name: "salt-master-config", path: "/etc/salt/master.d")
       ]
-    when /^velum-dashboard/, "velum-event-processor"
+    when /^velum-/
       [
         container_volume(name: "velum-source-code", path: "/srv/velum")
       ]


### PR DESCRIPTION
Depends on:

- https://github.com/kubic-project/caasp-container-manifests/pull/73