### PR TITLE
Include ETCD_INITIAL_CLUSTER on devenv etcd server

### DIFF
--- a/manifest-templates/etcd.yaml
+++ b/manifest-templates/etcd.yaml
@@ -21,3 +21,5 @@ spec:
       value: http://0.0.0.0:2379
     - name: ETCD_ADVERTISE_CLIENT_URLS
       value: http://${ip_address}:2379
+    - name: ETCD_INITIAL_CLUSTER
+      value: default=http://${ip_address}:2380


### PR DESCRIPTION
Without this variable, etcd version 3.2.4 fails to start with an error
indicating this value is required.