### PR TITLE
Pin etcd to 3.1.0 for release-1.0

### DIFF
--- a/manifest-templates/etcd.yaml
+++ b/manifest-templates/etcd.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: etcd
-    image: opensuse/etcd:development
+    image: opensuse/etcd:3.1.0
     imagePullPolicy: Always
     env:
     - name: ETCD_NAME


### PR DESCRIPTION
Newer versions of etcd require an updated configuration, for 1.0,
we should stick to the same version.