### PR TITLE
Use `latest` tag when `__TAG__` placeholder is found

### DIFF
--- a/process_manifest.rb
+++ b/process_manifest.rb
@@ -42,8 +42,9 @@ def patch_annotation_image(annotation)
 end
 
 def registry_container_image(container)
+  container_image = container["image"].gsub /__TAG__/, "latest"
   stage = ENV.fetch("STAGING", "release")
-  stage == "release" ? container["image"] : "#{ENV["STAGING"]}/#{container["image"]}"
+  stage == "release" ? container_image : "#{ENV["STAGING"]}/#{container_image}"
 end
 
 def patch_container_image(container)


### PR DESCRIPTION
The caasp-devenv should modify this placeholder in order to correctly
start the development environment. For now, we will just stick to the
`latest` tag instead.

(cherry picked from commit 2716c08601247ffa4210f8d32340f3992e82622f)